### PR TITLE
Update jsx template to use the ES2015 class syntax

### DIFF
--- a/bin/jsx/jsx.templates.js
+++ b/bin/jsx/jsx.templates.js
@@ -10,18 +10,19 @@ const React = require('react');
 const _     = require('lodash');
 const cx    = require('classnames');
 
-const ${Name} = React.createClass({
-	getDefaultProps: function() {
-		return {
+class ${Name} extends React.Component {
+    
+    constructor(props) {
+        super(props);
+    }
 
-		};
-	},
-	render: function(){
-		return <div className='${name}'>
-			${Name} Component Ready.
-		</div>
-	}
-});
+    render() {
+        return <div className='${name}'>
+            ${Name} Component Ready.
+        </div>
+    }
+
+}
 
 module.exports = ${Name};
 `;


### PR DESCRIPTION
The jsx command creates a new .jsx file for the specified component using `React.createClass`, which will be [deprecated by React v16](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html). This PR updates the template to use ES2015 classes instead, the new preferred method.

I've been using this version locally for a while now, but I thought it would be courteous to submit a PR.